### PR TITLE
Standardise the meta at the top of recommendations, include vote counts

### DIFF
--- a/php-di-adoption.md
+++ b/php-di-adoption.md
@@ -2,9 +2,9 @@
 
 The MODX Advisory Board recommends the MODX Project adopt PHP-DI as the Dependency Injection Container for MODX Revolution 3.x.
 
-**Editor: Jason Coward**
-**First published draft: October 20, 2016**
-
+* **Editor:** Jason Coward
+* **First published draft:** October 20, 2016
+* **Accepted:** December 8, 2016 with 14 votes in favour
 
 ## Goal of Recommendation
 

--- a/psr3-logging-standard.md
+++ b/psr3-logging-standard.md
@@ -2,10 +2,9 @@
 
 The PSR-3 Standard from the PHP-FIG contains an interface for a standardized logging solution. This standard has been widely adopted throughout the industry, and it is recommended that MODX 3 adopts this standard, and its most common implementation Monolog. This will benefit the project in terms of reduced code maintenance, a more powerful logging solution, and an increased appeal for developers.  
 
-Editor: Mark Hamstra
-
-First published draft: 2016-11-23
-
+* **Editor:** Mark Hamstra
+* **First published draft:** November 23, 2016
+* **Accepted:** December 21, 2016 with 11 votes in favour
 
 ## Goal of Recommendation
 

--- a/replace-3rd-party-libraries-with-composer-dependencies.md
+++ b/replace-3rd-party-libraries-with-composer-dependencies.md
@@ -2,8 +2,9 @@
 
 The MODX Advisory Board recommends the MODX Project replace all 3rd party code in the core of MODX Revolution 3.x with appropriate Composer dependencies.
 
-**Editor: Jason Coward**
-**First published draft: October 20, 2016**
+* **Editor:** Jason Coward
+* **First published draft:** October 20, 2016
+* **Accepted:** December 8, 2016 with 14 votes in favour
 
 
 ## Goal of Recommendation

--- a/restful-api-move-from-extjs.md
+++ b/restful-api-move-from-extjs.md
@@ -2,9 +2,9 @@
 
 Providing a 4-step process to decouple the MODX server-side code from the actions in the Manager interface, allowing development on the manager interface to take place without needing as much server-side knowledge. 
 
-Editor: Mark Hamstra
-
-First published draft: 2016-11-23
+* **Editor:** Mark Hamstra
+* **First published draft:** November 23, 2016
+* **Accepted:** December 21, 2016 with 12 votes in favour
 
 ## Goal of Recommendation
 

--- a/slim-refactor.md
+++ b/slim-refactor.md
@@ -2,9 +2,9 @@
 
 The MODX Advisory Board recommends the MODX Project to refactor the core MODX classes and model on top of Slim 3.x to accelerate the modernization of the core codebase.
 
-**Editor: Jason Coward**
-**First published draft: October 20, 2016**
-
+* **Editor:** Jason Coward
+* **First published draft:** October 20, 2016
+* **Accepted:** December 8, 2016 with 14 votes in favour
 
 ## Goal of Recommendation
 


### PR DESCRIPTION
Makes it a bit more consistent and readable. Having the vote counts in there might be nice for future reference so you don't have to search back the PR to see if a recommendation was accepted by a big or narrow margin. 