### PR TITLE
Recommendations Process addendum: allow editor to withdraw recommendation

### DIFF
--- a/withdraw-recommendations.md
+++ b/withdraw-recommendations.md
@@ -45,4 +45,4 @@ Immediately following the withdrawal of a recommendation currently under vote, t
 
 ## Upon Acceptance
 
-Should the recommendation be accepted, the Recommendations Process document should be updated to provide an addendum link to this recommendation.
+Should this recommendation be accepted, the Recommendations Process document should be updated to provide an addendum link to this recommendation.

--- a/withdraw-recommendations.md
+++ b/withdraw-recommendations.md
@@ -1,7 +1,7 @@
 Recommendation Addendum 1: Withdrawing during Review or Vote
 ################
 
-Should during the review or vote stage of the recommendation process a better alternative be proposed, this addendum provides the recommendation editor with the ability to withdraw the recommendation and to cancel the vote.
+Adds an addendum to the Recommendations Process that allows a recommendation editor ability to withdraw their recommendations from review or vote.
 
 * **Editor:** Mark Hamstra
 * **First published draft:** 2017-07-07
@@ -43,3 +43,6 @@ Depending on the used platform to collect reviews or votes, the editor should al
 
 Immediately following the withdrawal of a recommendation currently under vote, the vote is automatically cancelled and the recommendation rejected. 
 
+## Upon Acceptance
+
+Should the recommendation be accepted, the Recommendations Process document should be updated to provide an addendum link to this recommendation.

--- a/withdraw-recommendations.md
+++ b/withdraw-recommendations.md
@@ -1,0 +1,45 @@
+Recommendation Addendum 1: Withdrawing during Review or Vote
+################
+
+Should during the review or vote stage of the recommendation process a better alternative be proposed, this addendum provides the recommendation editor with the ability to withdraw the recommendation and to cancel the vote.
+
+* **Editor:** Mark Hamstra
+* **First published draft:** 2017-07-07
+* **Accepted:** Not yet voted.
+
+## Goal of Recommendation
+
+To add an addendum to the [Recommendations Process](https://docs.google.com/document/d/16aRId889oHBxnUB4kYpToNJsA9_IJfXqvuw0hw32MIU/edit) that allows a recommendation editor to withdraw a recommendation during review or vote.
+
+## Relevant Recommendations
+
+- [Recommendations Process](https://docs.google.com/document/d/16aRId889oHBxnUB4kYpToNJsA9_IJfXqvuw0hw32MIU/edit)
+
+## Recommendation
+
+When a recommendation has made it into the Review (step 2) or Vote (step 3) stage of the recommendations process, situations may occur where the editor of the recommendation wants to withdraw their recommendation. 
+
+This addendum defines the process for doing so.
+
+### Who?
+
+Only the editor, per the definition of that role in the Process section of the Recommendations Process document, may invoke this addendum to withdraw a recommendation from review or vote.
+
+Notably, the (Vice-) Chair does **not** receive the right to withdraw recommendations unless they are also the editor of the recommendation, as such a right could be misused as a veto. 
+
+### When?
+
+At any point during the Review or Vote stages of the recommendation process. During the Vote stage, the recommendation may only be withdrawn before all votes have been cast and before the vote has been called by the (Vice-) Chair. 
+
+### How?
+
+To withdraw the recommendation, the editor must post an unambiguous update to the recommendation review or vote thread invoking this addendum. An example of such an update:
+
+> As editor of this recommendation, I have decided to withdraw the recommendation from review and vote per Recommendations Process Addendum 1, because...
+
+This update must be made in writing, on a medium accessible to all MODX Advisory Board members, which is logged and available long term.  
+
+Depending on the used platform to collect reviews or votes, the editor should also close applicable tracking issues or cards. For example, a relevant GitHub pull request or issue should be marked as closed. 
+
+Immediately following the withdrawal of a recommendation currently under vote, the vote is automatically cancelled and the recommendation rejected. 
+


### PR DESCRIPTION
This recommendation proposes an addendum to the [Recommendations Process](https://docs.google.com/document/d/16aRId889oHBxnUB4kYpToNJsA9_IJfXqvuw0hw32MIU/edit) that allows a recommendation editor to withdraw a recommendation during review or vote.